### PR TITLE
Security: Fix incomplete URL substring sanitization

### DIFF
--- a/src/utils/config-validator.ts
+++ b/src/utils/config-validator.ts
@@ -45,10 +45,7 @@ export function validateInstanceConfig(
   } else {
     // Use exact suffix matching to detect when users include the full domain
     const normalizedDomain = config.domain.replace(/\/+$/, '').toLowerCase();
-    if (
-      normalizedDomain.endsWith('.atlassian.net') ||
-      normalizedDomain === 'atlassian.net'
-    ) {
+    if (normalizedDomain.endsWith('.atlassian.net') || normalizedDomain === 'atlassian.net') {
       warnings.push(
         `Instance '${instanceName}': domain should not include '.atlassian.net' - use just the subdomain`
       );

--- a/src/utils/config-validator.ts
+++ b/src/utils/config-validator.ts
@@ -42,13 +42,17 @@ export function validateInstanceConfig(
 
   if (!config.domain || config.domain.trim() === '') {
     errors.push(`Instance '${instanceName}': domain is required`);
-  } else if (
-    config.domain.endsWith('.atlassian.net') ||
-    config.domain.includes('.atlassian.net/')
-  ) {
-    warnings.push(
-      `Instance '${instanceName}': domain should not include '.atlassian.net' - use just the subdomain`
-    );
+  } else {
+    // Use exact suffix matching to detect when users include the full domain
+    const normalizedDomain = config.domain.replace(/\/+$/, '').toLowerCase();
+    if (
+      normalizedDomain.endsWith('.atlassian.net') ||
+      normalizedDomain === 'atlassian.net'
+    ) {
+      warnings.push(
+        `Instance '${instanceName}': domain should not include '.atlassian.net' - use just the subdomain`
+      );
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary
Fixes CodeQL high-severity alert: **Incomplete URL substring sanitization** in `config-validator.ts`.

The previous code used `.includes('.atlassian.net/')` which could match substrings anywhere in a URL. Replaced with proper suffix matching after normalization (strip trailing slashes, lowercase).

## Changes
- `src/utils/config-validator.ts`: Replace `.includes()` with `.endsWith()` after normalization

## Test plan
- [ ] Verify domain validation still warns on `mycompany.atlassian.net`
- [ ] Verify it accepts plain subdomains like `mycompany`