### PR TITLE
chore(ci): skip Claude Code Review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: github.actor != 'dependabot[bot]'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary
- Adds `if: github.actor != 'dependabot[bot]'` condition to the Claude Code Review workflow
- Prevents unnecessary workflow failures when Dependabot opens automated dependency bump PRs

## Test plan
- Verify Claude Code Review workflow no longer triggers on Dependabot PRs
- Verify it still triggers normally on human-authored PRs