### PR TITLE
fix(ci): add --legacy-peer-deps to resolve eslint/typescript-eslint conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Run security audit
         # Note: continue-on-error due to known MCP SDK vulnerability (GHSA-8r9q-7v3j-jr4g)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
           cache: 'npm'
 
       - name: Install and build
-        run: npm ci && npm run build
+        run: npm ci --legacy-peer-deps && npm run build
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a  # v3


### PR DESCRIPTION
## Summary
- Fixes CodeQL workflow failure due to npm ERESOLVE error
- ESLint 10.x is not yet supported by @typescript-eslint/eslint-plugin@8.x
- Adding --legacy-peer-deps allows npm ci to proceed with dependency resolution

## Test plan
- [ ] CodeQL workflow passes on this PR