### PR TITLE
fix(ci): use org-level reusable security workflows

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -14,31 +14,4 @@ permissions:
 
 jobs:
   semgrep:
-    name: Semgrep
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98  # v6.0.2
-
-      - name: Install Semgrep
-        run: pip install semgrep
-
-      - name: Run Semgrep
-        # No SEMGREP_APP_TOKEN = OSS mode, nothing sent to Semgrep cloud
-        run: |
-          semgrep scan \
-            --config=p/python \
-            --config=p/javascript \
-            --config=p/typescript \
-            --config=p/secrets \
-            --config=p/security-audit \
-            --sarif \
-            --output=semgrep.sarif \
-            . || true
-
-      - name: Upload Semgrep results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@77591e2c4a43bf190ac768983419eb058187e62f  # v3
-        if: always()
-        with:
-          sarif_file: semgrep.sarif
-          category: semgrep
+    uses: cfdude/.github/.github/workflows/security-semgrep.yml@main

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -14,25 +14,4 @@ permissions:
 
 jobs:
   trivy:
-    name: Trivy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98  # v6.0.2
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284  # 0.34.0
-        with:
-          scan-type: fs
-          scan-ref: .
-          format: sarif
-          output: trivy-results.sarif
-          severity: CRITICAL,HIGH
-          exit-code: 0  # Don't fail the build; results go to Security tab
-
-      - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@77591e2c4a43bf190ac768983419eb058187e62f  # v3
-        if: always()
-        with:
-          sarif_file: trivy-results.sarif
-          category: trivy
+    uses: cfdude/.github/.github/workflows/security-trivy.yml@main


### PR DESCRIPTION
## Summary
- Replaces standalone Trivy and Semgrep workflow definitions with thin callers to `cfdude/.github` org-level reusable workflows
- Fixes Trivy CI failure caused by broken pinned action version (`0.34.0` / `v0.69.1` binary download failure)
- Security workflows are now maintained centrally in the org repo, keeping all repos in sync with up-to-date action versions

## What changed
- `trivy.yml`: full job definition → `uses: cfdude/.github/.github/workflows/security-trivy.yml@main`
- `semgrep.yml`: full job definition → `uses: cfdude/.github/.github/workflows/security-semgrep.yml@main`

## Org workflow advantages over the local copies
- Trivy `0.35.0` (local was broken `0.34.0`)
- Archive-check gate (skips scans on archived repos)
- `continue-on-error` on SARIF upload (prevents failures on private repos without GHAS)
- Centrally updated action SHAs

## Test plan
- [ ] Verify Trivy Security Scan workflow passes on this PR
- [ ] Verify Semgrep SAST workflow passes on this PR