### PR TITLE
fix(ci): reject TypeScript major bumps in dep update workflow

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -36,7 +36,7 @@ jobs:
       id: check-updates
       run: |
         # Check for updates and save output
-        ncu --jsonUpgraded > updates.json
+        ncu --jsonUpgraded --reject typescript > updates.json
         
         # Check if there are updates
         if [ -s updates.json ] && [ "$(cat updates.json)" != "{}" ]; then
@@ -52,7 +52,7 @@ jobs:
       if: steps.check-updates.outputs.has-updates == 'true'
       run: |
         # Update dependencies
-        ncu -u
+        ncu -u --reject typescript
         npm install
 
     - name: Auto-format code


### PR DESCRIPTION
## Summary
- Adds `--reject typescript` to both `ncu` commands in the dependency update workflow
- Prevents TypeScript from being upgraded to v6.x, which breaks `@typescript-eslint/parser@8.57.2` (requires `typescript >=4.8.4 <6.0.0`)
- Closes the broken PR #30 which was created from a workflow run that hit this exact issue (npm ERESOLVE error)

## What changed
- `.github/workflows/dependency-updates.yml`: Added `--reject typescript` flag to `ncu --jsonUpgraded` and `ncu -u` commands

## Test plan
- [ ] Manually trigger the dependency update workflow via workflow_dispatch and verify it completes without ERESOLVE errors
- [ ] Verify TypeScript remains at its current version while other deps are updated