### PR TITLE
fix(config): add types:node for TypeScript 6 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Problem

The weekly **Dependency Updates** workflow runs `ncu -u` which upgrades TypeScript from `^5.x` to `^6.x`. TypeScript 6 changed behavior: when using `module: "Node16"`, it no longer implicitly includes `@types/node` globals (`fs`, `path`, `process`, `crypto`, `os`). This causes the build to fail with:

```
error TS2591: Cannot find name 'fs'. Do you need to install type definitions for node?
```

## Fix

Added `"types": ["node"]` to `tsconfig.json` compilerOptions. This is the TypeScript 6-recommended way to explicitly declare that Node.js type globals should be available.

## Impact

- Fixes the weekly Dependency Updates workflow (currently failing every Monday)
- No breaking changes to existing code